### PR TITLE
feat: add support to set priorityClassName

### DIFF
--- a/charts/node-latency-for-k8s-chart/templates/daemonset.yaml
+++ b/charts/node-latency-for-k8s-chart/templates/daemonset.yaml
@@ -57,3 +57,6 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}

--- a/charts/node-latency-for-k8s-chart/values.yaml
+++ b/charts/node-latency-for-k8s-chart/values.yaml
@@ -46,6 +46,7 @@ nodeSelector:
   kubernetes.io/os: linux
 tolerations: []
 affinity: {}
+priorityClassName: ""
 
 env:
   - name: PROMETHEUS_METRICS


### PR DESCRIPTION
**Issue** #42

**Description of changes:**
- Add support for the `priorityClassName` property on the podSpec section of the DaemonSet manifest.

**Tests:**
Tested by keeping the default value `""` which means the property won't be added. Also tested by setting the value to a propertyClassName of my cluster and deployed the rendered chart on my cluster.
```
cd charts/node-latency-for-k8s-chart
helm template --name-template node-latency --values=values.yaml .
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
