### PR TITLE
add arm64 to ko build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,10 @@
 SHELL=bash
 MAKEFILE_PATH = $(dir $(realpath -s $(firstword $(MAKEFILE_LIST))))
 BUILD_DIR_PATH = ${MAKEFILE_PATH}/build
-GOOS ?= linux
-GOARCH ?= amd64
 NLK_KO_DOCKER_REPO ?= ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com
 KO_DOCKER_REPO = ${NLK_KO_DOCKER_REPO}
-WITH_GOFLAGS = KO_DOCKER_REPO=${KO_DOCKER_REPO} GOOS=${GOOS} GOARCH=${GOARCH}
+WITH_GOFLAGS = KO_DOCKER_REPO=${KO_DOCKER_REPO}
+TARGET_PLATFORMS=linux/amd64,linux/arm64
 K8S_NODE_LATENCY_IAM_ROLE_ARN ?= arn:aws:iam::${AWS_ACCOUNT_ID}:role/${CLUSTER_NAME}-node-latency-for-k8s
 VERSION ?= $(shell git describe --tags --always --dirty)
 PREV_VERSION ?= $(shell git describe --abbrev=0 --tags `git rev-list --tags --skip=1 --max-count=1`)
@@ -16,7 +15,7 @@ toolchain: ## Install toolchain for development
 	hack/toolchain.sh
 
 build: ## Build the controller image
-	$(eval CONTROLLER_IMG=$(shell $(WITH_GOFLAGS) ko build -B -t $(VERSION) github.com/awslabs/node-latency-for-k8s/cmd/node-latency-for-k8s))
+	$(eval CONTROLLER_IMG=$(shell $(WITH_GOFLAGS) ko build -B --platform=$(TARGET_PLATFORMS) -t $(VERSION) github.com/awslabs/node-latency-for-k8s/cmd/node-latency-for-k8s))
 	$(eval CONTROLLER_TAG=$(shell echo ${CONTROLLER_IMG} | sed 's/.*node-latency-for-k8s://' | cut -d'@' -f1))
 	$(eval CONTROLLER_DIGEST=$(shell echo ${CONTROLLER_IMG} | sed 's/.*node-latency-for-k8s:.*@//'))
 	echo Built ${CONTROLLER_IMG}


### PR DESCRIPTION
removes `GOOS` and `GOARCH` in favor of `--platforms` to `ko build` args in order to enable multiple target platforms and support `arm64` which is already included in the binary releases (GoReleaser)

note: [`nodeSelector` value still contains `kubernetes.io/arch=amd64`](https://github.com/awslabs/node-latency-for-k8s/blob/370520c42f48b4afd5868e09d3bc358fb23748d3/charts/node-latency-for-k8s-chart/values.yaml#L45), but this can be changed by the user so there may not be a change necessary



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
