### PR TITLE
Update installation docs, make hostNetwork:true the hard-coded default for DaemonSet, changed podReadyStr

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ Usage for node-latency-for-k8s:
 
 ## Installation
 
+### Prerequisites
+
+- NLK currently only supports Amazon Linux 2 (AL2).
+- NLK requires IMDS access. To avoid using `HttpPutResponseHopLimit: 2` the DaemonSet now runs with `hostNetwork: true` by default which just requires `HttpPutResponseHopLimit: 1` and aligns with [EKS’ Best Practices](https://docs.aws.amazon.com/eks/latest/best-practices/identity-and-access-management.html).
+- *02-create-service-account.sh* utilizes [eksctl](https://github.com/eksctl-io/eksctl). Please make sure to install a recent version.
+
 ### K8s DaemonSet (Helm)
 
 ```
@@ -56,9 +62,9 @@ curl -Lo ${TEMP_DIR}/01-create-iam-policy.sh ${SCRIPTS_PATH}/01-create-iam-polic
 curl -Lo ${TEMP_DIR}/02-create-service-account.sh ${SCRIPTS_PATH}/02-create-service-account.sh
 curl -Lo ${TEMP_DIR}/cloudformation.yaml ${SCRIPTS_PATH}/cloudformation.yaml
 chmod +x ${TEMP_DIR}/01-create-iam-policy.sh ${TEMP_DIR}/02-create-service-account.sh
+export AWS_ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text)"
 ${TEMP_DIR}/01-create-iam-policy.sh && ${TEMP_DIR}/02-create-service-account.sh
 
-export AWS_ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text)"
 export KNL_IAM_ROLE_ARN="arn:aws:iam::${AWS_ACCOUNT_ID}:role/${CLUSTER_NAME}-node-latency-for-k8s"
 
 docker logout public.ecr.aws

--- a/charts/node-latency-for-k8s-chart/templates/daemonset.yaml
+++ b/charts/node-latency-for-k8s-chart/templates/daemonset.yaml
@@ -45,6 +45,7 @@ spec:
           hostPath:
             path: /var/log
             type: Directory
+      hostNetwork: true
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/pkg/latency/latency.go
+++ b/pkg/latency/latency.go
@@ -110,7 +110,7 @@ var (
 	vpcCNIInitialized     = regexp.MustCompile(`.*Successfully copied CNI plugin binary and config file.*`)
 	nodeReady             = regexp.MustCompile(`.*event="NodeReady".*`)
 	throttled             = regexp.MustCompile(`.*Waited for .* due to client-side throttling, not priority and fairness, request: .*`)
-	podReadyStr           = `.*%s/.* Type:ContainerStarted.*`
+	podReadyStr           = `.*%s/.*"Type":"ContainerStarted".*`
 )
 
 // New creates a new instance of a Measurer


### PR DESCRIPTION
*Issue [#172](https://github.com/awslabs/node-latency-for-k8s/issues/172)*

*Description of changes:*
- added *Prerequisites* section for installation
- changed installation order to avoid *02-create-service-account.sh* to fail
- hard-coded `hostNetwork: true` to DaemonSet to cope with *HttpPutResponseHopLimit* recommendations
- corrected *podReadyStr* in *latency.go* to reflect new kubelet output

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
